### PR TITLE
Fix silent string corruption when napi_create_string_* fails in extractStrings

### DIFF
--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -42,6 +42,10 @@ public:
 	uint32_t writePosition = 0;
 	uint32_t stringStart = 0;
 	uint32_t lastStringEnd = 0;
+	// set when a napi_create_string_* call fails (e.g. V8 string allocation failure); the scan
+	// stops and only the successfully created strings are returned, so the caller can safely
+	// re-extract from where we left off instead of consuming an uninitialized napi_value
+	bool failed = false;
 
 	void readString(napi_env env, uint32_t length, bool allowStringBlocks, napi_value* target) {
 		uint32_t start = position;
@@ -59,13 +63,19 @@ public:
 			// non-latin character
 			if (lastStringEnd) {
 				napi_value value;
-				napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value);
+				if (napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value) != napi_ok) {
+					failed = true;
+					return;
+				}
 				target[writePosition++] = value;
 				lastStringEnd = 0;
 			}
 			// use standard utf-8 conversion
 			napi_value value;
-			napi_create_string_utf8(env, (const char*) source + start, (int) length, &value);
+			if (napi_create_string_utf8(env, (const char*) source + start, (int) length, &value) != napi_ok) {
+				failed = true;
+				return;
+			}
 			target[writePosition++] = value;
 			position = end;
 			return;
@@ -74,7 +84,10 @@ public:
 		if (lastStringEnd) {
 			if (start - lastStringEnd > 40 || end - stringStart > 6000) {
 				napi_value value;
-				napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value);
+				if (napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value) != napi_ok) {
+					failed = true;
+					return;
+				}
 				target[writePosition++] = value;
 				stringStart = start;
 			}
@@ -88,9 +101,10 @@ public:
 		napi_value target[MAX_TARGET_SIZE + 1]; // leave one for the queued string
 		writePosition = 0;
 		lastStringEnd = 0;
+		failed = false;
 		position = startingPosition;
 		source = inputSource;
-		while (position < size) {
+		while (position < size && !failed) {
 			uint8_t token = source[position++];
 			if (token < 0xa0) {
 				// all one byte tokens
@@ -151,15 +165,26 @@ public:
 			}
 		}
 
-		if (lastStringEnd) {
+		if (lastStringEnd && !failed) {
 			napi_value value;
-			napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value);
-			if (writePosition == 0) {
-				return value;
+			if (napi_create_string_latin1(env, (const char*) source + stringStart, lastStringEnd - stringStart, &value) != napi_ok) {
+				failed = true;
+			} else {
+				if (writePosition == 0) {
+					return value;
+				}
+				target[writePosition++] = value;
 			}
-			target[writePosition++] = value;
 		} else if (writePosition == 1) {
 			return target[0];
+		}
+		if (failed && writePosition == 0) {
+			// nothing was successfully extracted; throw rather than returning an empty result the
+			// caller would interpret as "no strings here"
+			napi_throw_error(env, NULL, "msgpackr-extract: failed to create string (allocation failure?)");
+			napi_value undefinedValue;
+			napi_get_undefined(env, &undefinedValue);
+			return undefinedValue;
 		}
 		napi_value array;
 		#if ENABLE_V8_API


### PR DESCRIPTION
## Summary

`extractStrings` in `src/extract.cpp` ignores the `napi_status` returned by all four `napi_create_string_latin1`/`napi_create_string_utf8` call sites. When string creation fails (e.g. a V8 string-allocation failure under memory pressure), NAPI does **not** write the out value, so an uninitialized `napi_value` — in practice a stale stack slot, often a handle to a string from a *previous* extraction — is pushed into the result batch.

msgpackr consumes that batch blindly: the garbage entry gets matched to a bundled-string block, which shifts `srcStringStart`, and **every subsequent string in that block decodes as a length-preserving slice of the wrong bytes of the source buffer**. No error is thrown — the decode "succeeds" with silently corrupted strings.

We root-caused a production incident to this: a msgpack-cached schema snapshot decoded with an enum value of `"pId«Ob"` instead of `"String"` — byte-for-byte a −17-offset slice of the packed buffer (tail of the neighboring `shopId` key + the `0xAB` fixstr header + head of `ObjectField`). One process served corrupted data for ~3 hours until restart. Full analysis in [gadget-inc/gadget#20678](https://github.com/gadget-inc/gadget/pull/20678).

## The fix

- Check the status of every `napi_create_string_*` call. On failure, stop scanning and return only the successfully-created entries — the JS side already handles partial batches by calling `extractStrings` again from where it left off, so a transient allocation failure self-heals into a correct decode.
- If the *first* string creation fails (nothing valid to return), throw a descriptive error instead of returning an empty/garbage result, so a hard failure is loud rather than silent corruption.

Single-commit, single-file diff — no test infrastructure added, to match the repo's conventions.

## How it was verified

`napi_create_string_*` failure isn't reachable deterministically from JS (oversized-string allocation throws earlier, loudly), so I verified with a temporary fault-injection build on a separate branch — [`airhorns:fault-injection-repro`](https://github.com/airhorns/msgpackr-extract/compare/master...airhorns:msgpackr-extract:fault-injection-repro) — that adds an env-var hook simulating a failed creation (non-ok status, out value not written) plus a standalone regression test:

- **before this fix**: the test crashes with SIGSEGV (uninitialized `napi_value` dereferenced)
- **after**: entries created before the failure come back as a valid partial batch (all real content from the source buffer), and a failure with nothing extracted throws a real `Error`

Happy to fold that harness into this PR if you'd like it in-tree.

Normal-path behavior is unchanged — verified that bundled-block/utf8 extraction semantics are identical, and that a 191 KB production msgpack snapshot decodes **byte-identically** (sha256-equal JSON) through msgpackr 1.11.2 with this build vs. msgpackr's pure-JS fallback path.
